### PR TITLE
Adding link to Redis tutorial

### DIFF
--- a/node-sandbox/docs/TOC.md
+++ b/node-sandbox/docs/TOC.md
@@ -34,6 +34,10 @@
 
 ### [NPM packages](packages.md)
 
+### Jenkins
+
+### Terraform
+
 # Reference
 ## [Autogen'd Topic 1](#)
 ## [Autogen'd Topic 2](#)

--- a/node-sandbox/docs/TOC.md
+++ b/node-sandbox/docs/TOC.md
@@ -17,7 +17,9 @@
 
 ## Consume Azure services
 
-### [Provisioning a fully-managed MongoDB cluster](/azure/documentdb/documentdb-nodejs-application?toc=/node-sandbox/toc.json&bc=/node-sandbox/breadcrumb/toc.json)
+### [Provisioning a fully-managed MongoDB database](/azure/documentdb/documentdb-nodejs-application?toc=/node-sandbox/toc.json&bc=/node-sandbox/breadcrumb/toc.json)
+
+### [Creating and consuming a Redis cache](/azure/redis-cache/cache-nodejs-get-started?toc=/node-sandbox/toc.json&bc=/node-sandbox/breadcrumb/toc.json)
 
 ### Storage
 #### [Working with Blobs](/azure/storage/storage-nodejs-how-to-use-blob-storage?toc=/node-sandbox/toc.json&bc=/node-sandbox/breadcrumb/toc.json)


### PR DESCRIPTION
This PR simply adds a link to the existing Redis tutorial. I also tweaked the verbiage of the Mongo link.